### PR TITLE
更新 gradle plugin 版本至3.0.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,12 +33,12 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:26.1.0'
-    compile 'com.android.support.constraint:constraint-layout:1.0.2'
-    compile 'junit:junit:4.12'
-    androidTestCompile('com.android.support.test.espresso:espresso-core:3.0.1', {
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'com.android.support:appcompat-v7:26.1.0'
+    implementation 'com.android.support.constraint:constraint-layout:1.0.2'
+    implementation 'junit:junit:4.12'
+    androidTestImplementation('com.android.support.test.espresso:espresso-core:3.0.1', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile project(':keyboard')
+    implementation project(':keyboard')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,10 @@ subprojects {
             google()
         }
         dependencies {
-            classpath 'com.android.tools.build:gradle:2.3.3'
+            classpath 'com.android.tools.build:gradle:3.0.0'
+            classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
+            classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
+            classpath "org.jfrog.buildinfo:build-info-extractor-gradle:3.1.1"
         }
     }
 
@@ -20,7 +23,7 @@ subprojects {
 ext {
     minSdkVersion = 11
     compileSdkVersion = 26
-    buildToolsVersion = '26.0.1'
+    buildToolsVersion = '26.0.2'
     sourceCompatibility = JavaVersion.VERSION_1_7
 }
 

--- a/keyboard/build.gradle
+++ b/keyboard/build.gradle
@@ -1,11 +1,3 @@
-buildscript {
-    dependencies {
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
-        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:3.1.1"
-    }
-}
-
 apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
@@ -32,10 +24,10 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:25.1.0'
+    implementation 'com.android.support:support-v4:25.1.0'
 
-    compile 'org.mozilla:rhino:1.7.7.2'
-    compile 'com.annimon:stream:1.1.9'
+    implementation 'org.mozilla:rhino:1.7.7.2'
+    implementation 'com.annimon:stream:1.1.9'
 }
 
 // Create source/javadoc artifacts for publishing


### PR DESCRIPTION
1. 更新 gradle plugin 版本至3.0.0。
2. 将子项目的 buildscript 提至根项目的 build.gradle，以解决报错问题。