### PR TITLE
修复在4.4.2上选择框位置不正确的问题

### DIFF
--- a/keyboard/src/main/java/com/parkingwang/keyboard/view/InputView.java
+++ b/keyboard/src/main/java/com/parkingwang/keyboard/view/InputView.java
@@ -331,10 +331,7 @@ public class InputView extends LinearLayout {
                     mSelectedDrawable.setPosition(SelectedDrawable.Position.MIDDLE);
                 }
                 final Rect rect = mSelectedDrawable.getRect();
-                rect.setEmpty();
-                getChildVisibleRect(selected, rect, null);
-                rect.right = rect.left + selected.getWidth();
-                rect.bottom = rect.top + selected.getHeight();
+                rect.set(selected.getLeft(), selected.getTop(), selected.getRight(), selected.getBottom());
                 mSelectedDrawable.draw(canvas);
                 break;
             }


### PR DESCRIPTION
修改选中位置的获取方式，以修复在 4.4.2 上选中框位置不正确的问题。